### PR TITLE
Helm chart should use standard Helm labels & fullname

### DIFF
--- a/charts/speckle-server/templates/_helpers.tpl
+++ b/charts/speckle-server/templates/_helpers.tpl
@@ -1,0 +1,170 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "speckle.chartNameAndVersion" -}}
+{{- printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "speckle.chartName" -}}
+{{- $context := . -}}
+{{- default $context.Chart.Name $context.Values.chartNameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+Expects an argument which is a list of the context and the deployment name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "speckle.fullname" -}}
+{{- $context := index . 0 -}}
+{{- $deploymentName := index . 1 -}}
+{{- $deploymentNameSuffixLen := len $deploymentName | add1 -}}
+{{- if $context.Values.fullnameOverride -}}
+    {{- printf "%s-%s" $context.Values.fullnameOverride $deploymentName | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{- $chartName := default $context.Chart.Name $context.Values.chartNameOverride -}}
+    {{- if contains $chartName $context.Release.Name -}}
+        {{- printf "%s-%s" ($context.Release.Name | trunc (sub 63 $deploymentNameSuffixLen | int) | trimSuffix "-") $deploymentName -}}
+    {{- else -}}
+        {{- printf "%s-%s" (printf "%s-%s" $context.Release.Name $chartName | trunc (sub 63 $deploymentNameSuffixLen | int) | trimSuffix "-") $deploymentName -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "speckle.labels" -}}
+{{- $context := index . 0 -}}
+{{- $deploymentName := index . 1 -}}
+app: {{ include "speckle.fullname" (list $context $deploymentName) | quote }}
+helm.sh/chart: {{ include "speckle.chartName" $context | quote }}
+{{ include "speckle.selectorLabels" (list $context $deploymentName) }}
+app.kubernetes.io/managed-by: {{ $context.Release.Service | quote }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "speckle.selectorLabels" -}}
+{{- $context := index . 0 -}}
+{{- $deploymentName := index . 1 -}}
+app.kubernetes.io/name: {{ include "speckle.fullname" (list $context $deploymentName) | quote }}
+app.kubernetes.io/instance: {{ $context.Release.Name | quote }}
+{{ include "speckle.selectorLabels.serviceMonitor" (list $context $deploymentName) }}
+{{- end -}}
+
+{{/*
+Service monitor selector labels
+*/}}
+{{- define "speckle.selectorLabels.serviceMonitor" -}}
+{{- $context := index . 0 -}}
+{{- $deploymentName := index . 1 -}}
+project: {{ include "speckle.chartName" $context | quote }}
+{{- end -}}
+
+{{/*
+=========== backend ===========
+*/}}
+{{- define "speckle.fullname.backend" -}}
+{{- include "speckle.fullname" (list . "speckle-server" ) -}}
+{{- end -}}
+
+{{- define "speckle.labels.backend" -}}
+{{- include "speckle.labels" (list . "speckle-server") -}}
+{{- end -}}
+
+{{- define "speckle.selectorLabels.backend" -}}
+{{- include "speckle.selectorLabels" (list . "speckle-server") -}}
+{{- end -}}
+
+{{/*
+=========== fileimport-service ===========
+*/}}
+{{- define "speckle.fullname.fileimport-service" -}}
+{{- include "speckle.fullname" (list . "fileimport-service" ) -}}
+{{- end -}}
+
+{{- define "speckle.labels.fileimport-service" -}}
+{{- include "speckle.labels" (list . "fileimport-service") -}}
+{{- end -}}
+
+{{- define "speckle.selectorLabels.fileimport-service" -}}
+{{- include "speckle.selectorLabels" (list . "fileimport-service") -}}
+{{- end -}}
+
+{{/*
+=========== frontend ===========
+*/}}
+{{- define "speckle.fullname.frontend" -}}
+{{- include "speckle.fullname" (list . "frontend" ) -}}
+{{- end -}}
+
+{{- define "speckle.labels.frontend" -}}
+{{- include "speckle.labels" (list . "frontend") -}}
+{{- end -}}
+
+{{- define "speckle.selectorLabels.frontend" -}}
+{{- include "speckle.selectorLabels" (list . "frontend") -}}
+{{- end -}}
+
+{{/*
+=========== monitoring ===========
+*/}}
+{{- define "speckle.fullname.monitoring" -}}
+{{- include "speckle.fullname" (list . "monitoring" ) -}}
+{{- end -}}
+
+{{- define "speckle.labels.monitoring" -}}
+{{- include "speckle.labels" (list . "monitoring") -}}
+{{- end -}}
+
+{{- define "speckle.selectorLabels.monitoring" -}}
+{{- include "speckle.selectorLabels" (list . "monitoring") -}}
+{{- end -}}
+
+{{/*
+=========== preview-service ===========
+*/}}
+{{- define "speckle.fullname.preview-service" -}}
+{{- include "speckle.fullname" (list . "preview-service" ) -}}
+{{- end -}}
+
+{{- define "speckle.labels.preview-service" -}}
+{{- include "speckle.labels" (list . "preview-service") -}}
+{{- end -}}
+
+{{- define "speckle.selectorLabels.preview-service" -}}
+{{- include "speckle.selectorLabels" (list . "preview-service") -}}
+{{- end -}}
+
+{{/*
+=========== webhook-service ===========
+*/}}
+{{- define "speckle.fullname.webhook-service" -}}
+{{- include "speckle.fullname" (list . "webhook-service" ) -}}
+{{- end -}}
+
+{{- define "speckle.labels.webhook-service" -}}
+{{- include "speckle.labels" (list . "webhook-service") -}}
+{{- end -}}
+
+{{- define "speckle.selectorLabels.webhook-service" -}}
+{{- include "speckle.selectorLabels" (list . "webhook-service") -}}
+{{- end -}}
+
+{{/*
+=========== test-deployment ===========
+*/}}
+{{- define "speckle.fullname.test-deployment" -}}
+{{- include "speckle.fullname" (list . "test-deployment" ) -}}
+{{- end -}}
+
+{{- define "speckle.labels.test-deployment" -}}
+{{- include "speckle.labels" (list . "test-deployment") -}}
+{{- end -}}

--- a/charts/speckle-server/templates/_helpers.tpl
+++ b/charts/speckle-server/templates/_helpers.tpl
@@ -72,99 +72,99 @@ project: {{ include "speckle.chartName" $context | quote }}
 =========== backend ===========
 */}}
 {{- define "speckle.fullname.backend" -}}
-{{- include "speckle.fullname" (list . "speckle-server" ) -}}
+{{- include "speckle.fullname" (list $ "speckle-server" ) -}}
 {{- end -}}
 
 {{- define "speckle.labels.backend" -}}
-{{- include "speckle.labels" (list . "speckle-server") -}}
+{{- include "speckle.labels" (list $ "speckle-server") -}}
 {{- end -}}
 
 {{- define "speckle.selectorLabels.backend" -}}
-{{- include "speckle.selectorLabels" (list . "speckle-server") -}}
+{{- include "speckle.selectorLabels" (list $ "speckle-server") -}}
 {{- end -}}
 
 {{/*
 =========== fileimport-service ===========
 */}}
 {{- define "speckle.fullname.fileimport-service" -}}
-{{- include "speckle.fullname" (list . "fileimport-service" ) -}}
+{{- include "speckle.fullname" (list $ "fileimport-service" ) -}}
 {{- end -}}
 
 {{- define "speckle.labels.fileimport-service" -}}
-{{- include "speckle.labels" (list . "fileimport-service") -}}
+{{- include "speckle.labels" (list $ "fileimport-service") -}}
 {{- end -}}
 
 {{- define "speckle.selectorLabels.fileimport-service" -}}
-{{- include "speckle.selectorLabels" (list . "fileimport-service") -}}
+{{- include "speckle.selectorLabels" (list $ "fileimport-service") -}}
 {{- end -}}
 
 {{/*
 =========== frontend ===========
 */}}
 {{- define "speckle.fullname.frontend" -}}
-{{- include "speckle.fullname" (list . "frontend" ) -}}
+{{- include "speckle.fullname" (list $ "frontend" ) -}}
 {{- end -}}
 
 {{- define "speckle.labels.frontend" -}}
-{{- include "speckle.labels" (list . "frontend") -}}
+{{- include "speckle.labels" (list $ "frontend") -}}
 {{- end -}}
 
 {{- define "speckle.selectorLabels.frontend" -}}
-{{- include "speckle.selectorLabels" (list . "frontend") -}}
+{{- include "speckle.selectorLabels" (list $ "frontend") -}}
 {{- end -}}
 
 {{/*
 =========== monitoring ===========
 */}}
 {{- define "speckle.fullname.monitoring" -}}
-{{- include "speckle.fullname" (list . "monitoring" ) -}}
+{{- include "speckle.fullname" (list $ "monitoring" ) -}}
 {{- end -}}
 
 {{- define "speckle.labels.monitoring" -}}
-{{- include "speckle.labels" (list . "monitoring") -}}
+{{- include "speckle.labels" (list $ "monitoring") -}}
 {{- end -}}
 
 {{- define "speckle.selectorLabels.monitoring" -}}
-{{- include "speckle.selectorLabels" (list . "monitoring") -}}
+{{- include "speckle.selectorLabels" (list $ "monitoring") -}}
 {{- end -}}
 
 {{/*
 =========== preview-service ===========
 */}}
 {{- define "speckle.fullname.preview-service" -}}
-{{- include "speckle.fullname" (list . "preview-service" ) -}}
+{{- include "speckle.fullname" (list $ "preview-service" ) -}}
 {{- end -}}
 
 {{- define "speckle.labels.preview-service" -}}
-{{- include "speckle.labels" (list . "preview-service") -}}
+{{- include "speckle.labels" (list $ "preview-service") -}}
 {{- end -}}
 
 {{- define "speckle.selectorLabels.preview-service" -}}
-{{- include "speckle.selectorLabels" (list . "preview-service") -}}
+{{- include "speckle.selectorLabels" (list $ "preview-service") -}}
 {{- end -}}
 
 {{/*
 =========== webhook-service ===========
 */}}
 {{- define "speckle.fullname.webhook-service" -}}
-{{- include "speckle.fullname" (list . "webhook-service" ) -}}
+{{- include "speckle.fullname" (list $ "webhook-service" ) -}}
 {{- end -}}
 
 {{- define "speckle.labels.webhook-service" -}}
-{{- include "speckle.labels" (list . "webhook-service") -}}
+{{- include "speckle.labels" (list $ "webhook-service") -}}
 {{- end -}}
 
 {{- define "speckle.selectorLabels.webhook-service" -}}
-{{- include "speckle.selectorLabels" (list . "webhook-service") -}}
+{{- include "speckle.selectorLabels" (list $ "webhook-service") -}}
 {{- end -}}
 
 {{/*
 =========== test-deployment ===========
 */}}
 {{- define "speckle.fullname.test-deployment" -}}
-{{- include "speckle.fullname" (list . "test-deployment" ) -}}
+{{- include "speckle.fullname" (list $ "test-deployment" ) -}}
 {{- end -}}
 
 {{- define "speckle.labels.test-deployment" -}}
-{{- include "speckle.labels" (list . "test-deployment") -}}
+{{- include "speckle.labels" (list $ "test-deployment") -}}
 {{- end -}}

--- a/charts/speckle-server/templates/deployment-backend.yml
+++ b/charts/speckle-server/templates/deployment-backend.yml
@@ -1,22 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: speckle-server
+  name: {{ include "speckle.fullname.backend" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-server
-    project: speckle-server
+{{ include "speckle.labels.backend" $ | indent 4 }}
 spec:
   replicas: {{ .Values.server.replicas }}
   selector:
     matchLabels:
-      app: speckle-server
-      project: speckle-server
+{{ include "speckle.selectorLabels.backend" $ | indent 6 }}
   template:
     metadata:
       labels:
-        app: speckle-server
-        project: speckle-server
+{{ include "speckle.labels.backend" $ | indent 8 }}
     spec:
       priorityClassName: high-priority
 

--- a/charts/speckle-server/templates/deployment-fileimport-service.yml
+++ b/charts/speckle-server/templates/deployment-fileimport-service.yml
@@ -3,31 +3,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: speckle-fileimport-service
+  name: {{ include "speckle.fullname.fileimport-service" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-fileimport-service
-    project: speckle-server
+{{ include "speckle.labels.fileimport-service" $ | indent 4 }}
 spec:
   replicas: {{ .Values.fileimport_service.replicas }}
   selector:
     matchLabels:
-      app: speckle-fileimport-service
-      project: speckle-server
+{{ include "speckle.selectorLabels.fileimport-service" $ | indent 6 }}
   template:
     metadata:
       labels:
-        app: speckle-fileimport-service
-        project: speckle-server
+{{ include "speckle.labels.fileimport-service" $ | indent 8 }}
     spec:
       priorityClassName: low-priority
 
-      {{- if .Values.db.useCertificate }}
+      {{- if .Values.db.useCertificate -}}
       volumes:
         - name: postgres-certificate
           configMap:
             name: postgres-certificate
-      {{- end }}
+      {{- end -}}
 
       # Should be > File import timeout to allow finishing up imports
       terminationGracePeriodSeconds: 610

--- a/charts/speckle-server/templates/deployment-frontend.yml
+++ b/charts/speckle-server/templates/deployment-frontend.yml
@@ -1,22 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: speckle-frontend
+  name: {{ include "speckle.fullname.frontend" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-frontend
-    project: speckle-server
+{{ include "speckle.labels.frontend" $ | indent 4 }}
 spec:
   replicas: {{ .Values.frontend.replicas }}
   selector:
     matchLabels:
-      app: speckle-frontend
-      project: speckle-server
+{{ include "speckle.selectorLabels.frontend" $ | indent 6 }}
   template:
     metadata:
       labels:
-        app: speckle-frontend
-        project: speckle-server
+{{ include "speckle.labels.frontend" $ | indent 8 }}
     spec:
       priorityClassName: high-priority
 

--- a/charts/speckle-server/templates/deployment-monitor-deployment.yml
+++ b/charts/speckle-server/templates/deployment-monitor-deployment.yml
@@ -1,22 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: speckle-monitoring
+  name: {{ include "speckle.fullname.monitoring" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-monitoring
-    project: speckle-server
+{{ include "speckle.labels.monitoring" $ | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: speckle-monitoring
-      project: speckle-server
+{{ include "speckle.selectorLabels.monitoring" $ | indent 6 }}
   template:
     metadata:
       labels:
-        app: speckle-monitoring
-        project: speckle-server
+{{ include "speckle.labels.monitoring" $ | indent 8 }}
     spec:
       priorityClassName: low-priority
 

--- a/charts/speckle-server/templates/deployment-preview-service.yml
+++ b/charts/speckle-server/templates/deployment-preview-service.yml
@@ -1,22 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: speckle-preview-service
+  name: {{ include "speckle.fullname.preview-service" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-preview-service
-    project: speckle-server
+{{ include "speckle.labels.preview-service" $ | indent 4 }}
 spec:
   replicas: {{ .Values.preview_service.replicas }}
   selector:
     matchLabels:
-      app: speckle-preview-service
-      project: speckle-server
+{{ include "speckle.selectorLabels.preview-service" $ | indent 6 }}
   template:
     metadata:
       labels:
-        app: speckle-preview-service
-        project: speckle-server
+{{ include "speckle.labels.preview-service" $ | indent 8 }}
     spec:
       priorityClassName: low-priority
 

--- a/charts/speckle-server/templates/deployment-webhook-service.yml
+++ b/charts/speckle-server/templates/deployment-webhook-service.yml
@@ -1,22 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: speckle-webhook-service
+  name: {{ include "speckle.fullname.webhook-service" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-webhook-service
-    project: speckle-server
+{{ include "speckle.labels.webhook-service" $ | indent 4 }}
 spec:
   replicas: {{ .Values.webhook_service.replicas }}
   selector:
     matchLabels:
-      app: speckle-webhook-service
-      project: speckle-server
+{{ include "speckle.selectorLabels.webhook-service" $ | indent 6 }}
   template:
     metadata:
       labels:
-        app: speckle-webhook-service
-        project: speckle-server
+{{ include "speckle.labels.webhook-service" $ | indent 8 }}
     spec:
       priorityClassName: low-priority
 

--- a/charts/speckle-server/templates/servicemonitor.yml
+++ b/charts/speckle-server/templates/servicemonitor.yml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      project: speckle-server
+{{ include "speckle.selectorLabels.serviceMonitor" $ | indent 6 }}
   endpoints:
   - port: web
 

--- a/charts/speckle-server/templates/services.yml
+++ b/charts/speckle-server/templates/services.yml
@@ -1,15 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: speckle-server
+  name: {{ include "speckle.fullname.backend" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-server
-    project: speckle-server
+{{ include "speckle.labels.backend" $ | indent 4 }}
 spec:
   selector:
-    app: speckle-server
-    project: speckle-server
+{{ include "speckle.selectorLabels.backend" $ | indent 4 }}
   ports:
     - protocol: TCP
       name: web
@@ -19,15 +17,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: speckle-frontend
+  name: {{ include "speckle.fullname.frontend" $ }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-frontend
-    project: speckle-server
+{{ include "speckle.labels.frontend" $ | indent 4 }}
 spec:
   selector:
-    app: speckle-frontend
-    project: speckle-server
+{{ include "speckle.selectorLabels.frontend" $ | indent 4 }}
   ports:
     - protocol: TCP
       name: www
@@ -37,51 +33,47 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: speckle-preview-service-metrics
+  name: {{- include "speckle.fullname" (list $ "preview-service-metrics") -}}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-preview-service-metrics
-    project: speckle-server
+{{ include "speckle.labels" (list $ "preview-service-metrics") | indent 4 }}
 spec:
   selector:
-    app: speckle-preview-service
-    project: speckle-server
+{{ include "speckle.selectorLabels.preview-service" $ | indent 4 }}
   ports:
     - protocol: TCP
       name: web
       port: 9094
       targetPort: 9094
+{{- if .Values.s3.endpoint -}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: speckle-fileimport-service-metrics
+  name: {{- include "speckle.fullname" (list $ "fileimport-service-metrics") -}}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-fileimport-service-metrics
-    project: speckle-server
+{{ include "speckle.labels" (list $ "fileimport-service-metrics") | indent 4 }}
 spec:
   selector:
-    app: speckle-fileimport-service
-    project: speckle-server
+{{ include "speckle.selectorLabels.fileimport-service" $ | indent 4 }}
   ports:
     - protocol: TCP
       name: web
       port: 9093
       targetPort: 9093
+{{- end -}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: speckle-webhook-service-metrics
+  name: {{- include "speckle.fullname" (list $ "webhook-service-metrics") -}}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-webhook-service
-    project: speckle-server
+{{ include "speckle.labels" (list $ "webhook-service-metrics") | indent 4 }}
 spec:
   selector:
-    app: speckle-webhook-service
-    project: speckle-server
+{{ include "speckle.selectorLabels.webhook-service" $ | indent 4 }}
   ports:
     - protocol: TCP
       name: web
@@ -91,15 +83,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: speckle-monitoring-metrics
+  name:  {{- include "speckle.fullname" (list $ "monitoring-service-metrics") -}}
   namespace: {{ .Values.namespace }}
   labels:
-    app: speckle-monitoring
-    project: speckle-server
+{{ include "speckle.labels" (list $ "monitoring-service-metrics") | indent 4 }}
 spec:
   selector:
-    app: speckle-monitoring
-    project: speckle-server
+{{ include "speckle.selectorLabels.monitoring" $ | indent 4 }}
   ports:
     - protocol: TCP
       name: web

--- a/charts/speckle-server/templates/test/test-deployment.yaml
+++ b/charts/speckle-server/templates/test/test-deployment.yaml
@@ -1,22 +1,22 @@
-{{- if .Values.helm_test_enabled }}
+{{- if .Values.helm_test_enabled -}}
+{{- $deploymentName := "test-deployment" -}}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "speckle-test-deployment"
+  name: {{ include "speckle.fullname.test-deployment" $ }}
   namespace: {{ .Values.namespace }}
   annotations:
     "helm.sh/hook": test
   labels:
-    app: speckle-test-deployment
-    project: speckle-server
+{{ include "speckle.labels.test-deployment" $ | indent 4 }}
 spec:
   containers:
-    - name: test-deployment
+    - name: {{ $deploymentName }}
       image: speckle/speckle-test-deployment:{{ .Values.docker_image_tag }}
       env:
         - name: SPECKLE_SERVER
-          value: https://{{ .Values.domain }}
+          value: "https://{{ .Values.domain }}"
         - name: SERVER_VERSION
-          value: {{ .Values.docker_image_tag }}
+          value: {{ .Values.docker_image_tag | quote }}
   restartPolicy: Never
-{{- end }}
+{{- end -}}


### PR DESCRIPTION
* fullname of `$chart-$release-$service` is used
  * this enables multiple releases to be deployed within a namespace
  * it makes it slightly easier to identify at first glance which chart/release is responsible for each pod.
  * the fullname may take the form of `$chart-$service`, where chart is same as release
  * where fullname is greater than 63 characters (limited by DNS), the `$service` suffix is retained and `$chart-$release-` (or `$chart-`) prefix is truncated to ensure it fits within the character limit.

* [standard `app.kubernetes.io/*` labels](https://helm.sh/docs/chart_best_practices/labels/#standard-labels) are included
* selection is by the standard `app.kubernetes.io` labels
* original `name` and `project` labels are retained.
  * service monitor continues to select by `project` label