### PR TITLE
Define named ports on all pods

### DIFF
--- a/charts/speckle-server/templates/deployment-backend.yml
+++ b/charts/speckle-server/templates/deployment-backend.yml
@@ -32,7 +32,10 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-server:{{ .Values.docker_image_tag }}
-
+        ports:
+          - name: http
+            containerPort: 3000
+            protocol: TCP
         resources:
           requests:
             cpu: {{ .Values.server.requests.cpu }}

--- a/charts/speckle-server/templates/deployment-backend.yml
+++ b/charts/speckle-server/templates/deployment-backend.yml
@@ -32,10 +32,12 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-server:{{ .Values.docker_image_tag }}
+
         ports:
           - name: http
             containerPort: 3000
             protocol: TCP
+
         resources:
           requests:
             cpu: {{ .Values.server.requests.cpu }}

--- a/charts/speckle-server/templates/deployment-fileimport-service.yml
+++ b/charts/speckle-server/templates/deployment-fileimport-service.yml
@@ -36,6 +36,11 @@ spec:
       - name: main
         image: speckle/speckle-fileimport-service:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9093
+            protocol: TCP
+
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/charts/speckle-server/templates/deployment-frontend.yml
+++ b/charts/speckle-server/templates/deployment-frontend.yml
@@ -23,6 +23,12 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-frontend:{{ .Values.docker_image_tag }}
+
+        ports:
+          - name: www
+            containerPort: 80
+            protocol: TCP
+
         resources:
           requests:
             cpu: {{ .Values.frontend.requests.cpu }}

--- a/charts/speckle-server/templates/deployment-monitor-deployment.yml
+++ b/charts/speckle-server/templates/deployment-monitor-deployment.yml
@@ -33,6 +33,11 @@ spec:
       - name: main
         image: speckle/speckle-monitor-deployment:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9092
+            protocol: TCP
+
         resources:
           requests:
             cpu: 100m

--- a/charts/speckle-server/templates/deployment-preview-service.yml
+++ b/charts/speckle-server/templates/deployment-preview-service.yml
@@ -34,6 +34,11 @@ spec:
       - name: main
         image: speckle/speckle-preview-service:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9094
+            protocol: TCP
+
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/charts/speckle-server/templates/deployment-webhook-service.yml
+++ b/charts/speckle-server/templates/deployment-webhook-service.yml
@@ -34,6 +34,11 @@ spec:
       - name: main
         image: speckle/speckle-webhook-service:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9095
+            protocol: TCP
+
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/charts/speckle-server/templates/services.yml
+++ b/charts/speckle-server/templates/services.yml
@@ -14,7 +14,7 @@ spec:
     - protocol: TCP
       name: web
       port: 3000
-      targetPort: 3000
+      targetPort: http
 ---
 apiVersion: v1
 kind: Service
@@ -32,7 +32,7 @@ spec:
     - protocol: TCP
       name: www
       port: 80
-      targetPort: 80
+      targetPort: www
 ---
 apiVersion: v1
 kind: Service
@@ -50,7 +50,7 @@ spec:
     - protocol: TCP
       name: web
       port: 9094
-      targetPort: 9094
+      targetPort: metrics
 ---
 apiVersion: v1
 kind: Service
@@ -68,7 +68,7 @@ spec:
     - protocol: TCP
       name: web
       port: 9093
-      targetPort: 9093
+      targetPort: metrics
 ---
 apiVersion: v1
 kind: Service
@@ -86,7 +86,7 @@ spec:
     - protocol: TCP
       name: web
       port: 9095
-      targetPort: 9095
+      targetPort: metrics
 ---
 apiVersion: v1
 kind: Service
@@ -104,4 +104,4 @@ spec:
     - protocol: TCP
       name: web
       port: 9092
-      targetPort: 9092
+      targetPort: metrics


### PR DESCRIPTION
Ports on containers are given a defined name in the PR.

The corresponding service refers to the named target port.

This allows changes to be made to the container port number without requiring changes to the service.  It also makes the intent of the exposed port clearer.