### PR TITLE
Allows the monitoring namespace to be distinct from Speckle namespace

### DIFF
--- a/charts/speckle-server/templates/servicemonitor.yml
+++ b/charts/speckle-server/templates/servicemonitor.yml
@@ -1,10 +1,10 @@
-{{ if .Values.enable_prometheus_monitoring }}
+{{ if .Values.monitoring.enabled }}
 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: speckle-server
-  namespace: {{ .Values.namespace }}
+  namespace: {{ default .Values.namespace .Values.monitoring.namespace }}
   labels:
     app: speckle-server
     release: kube-prometheus-stack

--- a/charts/speckle-server/templates/servicemonitor.yml
+++ b/charts/speckle-server/templates/servicemonitor.yml
@@ -7,8 +7,11 @@ metadata:
   namespace: {{ default .Values.namespace .Values.monitoring.namespace }}
   labels:
     app: speckle-server
-    release: kube-prometheus-stack
+    release: {{ .Values.monitoring.release }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.namespace }}
   selector:
     matchLabels:
       project: speckle-server

--- a/charts/speckle-server/values.yaml
+++ b/charts/speckle-server/values.yaml
@@ -97,7 +97,10 @@ fileimport_service:
 
 secretName: server-vars
 
-enable_prometheus_monitoring: false
+monitoring:
+  enabled: false
+  namespace: "" # the namespace in which prometheus is deployed; defaults to .Values.namespace if not provided
+
 cert_manager_issuer: letsencrypt-staging
 
 helm_test_enabled: true

--- a/charts/speckle-server/values.yaml
+++ b/charts/speckle-server/values.yaml
@@ -100,6 +100,7 @@ secretName: server-vars
 monitoring:
   enabled: false
   namespace: "" # the namespace in which prometheus is deployed; defaults to .Values.namespace if not provided
+  release: "" # the release name of the prometheus deployment
 
 cert_manager_issuer: letsencrypt-staging
 


### PR DESCRIPTION
* this allows prometheus/grafana to be deployed in a different namespace
from speckle
* ServiceMonitor will be deployed in this monitoring namespace.  Defaults to the speckle namespace if no value is explicitly defined.
* flag to deploy servicemonitor now follows `.Values.X.enabled` convention