### PR TITLE
fix(github): workflows in a race were causing errors

### DIFF
--- a/.github/workflows/update-gh-pages-readme.yml
+++ b/.github/workflows/update-gh-pages-readme.yml
@@ -9,7 +9,7 @@ on:
       - .github/dependabot.yml
 
 concurrency:
-  group: update-readme-commit-${{github.sha}}
+  group: update-readme-commit
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
- amend the concurrency group of updating GH pages README, so that later commits win